### PR TITLE
New code of conduct + incident response policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,52 +1,62 @@
+# imgix Code of Conduct
+
 *This policy is a "living" document, and subject to refinement and expansion in the future.*
 
-The "imgix-community" Slack chat room should be a safe place for everyone, regardless of
+imgix is dedicated to providing a harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of participants in any form.
 
-- gender, gender identity, or gender expression
-- sexual orientation
-- disability
-- physical appearance (including but not limited to body size)
-- race
-- age
-- religion
+This code of conduct applies to all imgix sponsored spaces, including our [community Slack](http://slack.imgix.com), [open-source projects](https://github.com/imgix), and other spaces that imgix hosts, both online and off. Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the imgix Anti-Abuse Team (<codeofconduct@imgix.com>).
 
-As someone who is part of this community, you agree that:
-
-* We are collectively and individually committed to safety and inclusivity.
-* We have zero tolerance for abuse, harassment, or discrimination.
-* We respect people’s boundaries and identities.
-* We refrain from using language that can be considered oppressive (systemically or otherwise), eg. sexist, racist, homophobic, transphobic, ableist, classist, etc. - this includes (but is not limited to) various slurs.
-* We avoid using offensive topics as a form of humor.
+Some imgix-sponsored spaces may have additional rules in place, which will be made clearly available to participants. Participants are responsible for knowing and abiding by these rules.
 
 
-We actively work towards:
+## Definitions
 
-* Being a safe community
-* Cultivating a network of support & encouragement for each other
-* Encouraging responsible and varied forms of expression
+Harassment includes:
+
+* Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, or religion
+* Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
+* Deliberate misgendering or use of ‘dead’ or rejected names
+* Gratuitous or off-topic sexual images or behaviour  in spaces where they’re not appropriate
+* Physical contact and simulated physical contact (eg, textual descriptions like “*hug*” or “*backrub*”) without consent or after a request to stop.
+* Threats of violence
+* Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm
+* Deliberate intimidation
+* Stalking or following
+* Harassing photography or recording, including logging online activity for harassment purposes
+* Sustained disruption of discussion
+* Unwelcome sexual attention
+* Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others
+* Continued one-on-one communication after requests to cease
+* Deliberate “outing” of any aspect of a person’s identity without their consent except as necessary to protect other imgix community members or other vulnerable people from intentional abuse
+* Publication of non-harassing private communication
+
+The imgix community prioritizes marginalized people’s safety over privileged people’s comfort. The imgix Anti-Abuse Team will not act on complaints regarding:
+
+* ‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’
+* Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you.”
+* Refusal to explain or debate social justice concepts
+* Communicating in a ‘tone’ you don’t find congenial
+* Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions
 
 
-We condemn:
+## Reporting
 
-* Stalking, doxxing, or publishing private information
-* Threats of harm, harassment
-* Anything that compromises people’s safety
-* Posting of illegal content
+If you are being harassed by a member of the imgix community, notice that someone else is being harassed, or have any other concerns, please contact the imgix Anti-Abuse Team at <codeofconduct@imgix.com>. If the person who is harassing you is on the team, they will recuse themselves from handling your incident. We will respond as promptly as we can.
 
-**These things are NOT OK.**
+This code of conduct applies to imgix sponsored spaces, but if you are being harassed by a member of the imgix community outside our spaces, we still want to know about it. We will take all good-faith reports of harassment by imgix community members seriously. This includes harassment outside our spaces and harassment that took place at any point in time. The abuse team reserves the right to exclude people from the imgix community based on their past behavior, including behavior outside imgix spaces and behavior towards people who are not in the imgix community.
 
-If you say something that is found offensive, and you are called out on it, please:
+In order to protect volunteers from abuse and burnout, we reserve the right to reject any report we believe to have been made in bad faith. The imgix Anti-Abuse Team is not here to explain power differentials or other basic social justice concepts to you. Reports intended to silence legitimate criticism may be deleted without response.
 
-* Listen without interruption.
-* Believe what the person is saying & do not attempt to disqualify what they have to say.
-* Ask for tips / help with avoiding making the offense in the future.
-* Apologize and ask forgiveness.
-
-Failing to follow the community guidelines as described in this document carries consequences. For minor infractions, you may be temporarily suspended from the community. Upon repeat offenses, or if the community believes you are not acting in good faith, you may be asked to leave permanently.
+We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of imgix members or the general public. We will not name harassment victims without their affirmative consent.
 
 
-**If you experience abuse, harassment, discrimination, or feel unsafe, let an operator know. Here is a list of the current operators and their Slack IDs:**
+## Consequences
 
-* Paul Straw - @paulstraw
+Participants asked to stop any harassing behavior are expected to comply immediately.
 
-*The role of the moderators is to be an unbiased mediator, they will not moderate or edit anything written in the chat room unless it is required as a result of a discussed dispute.*
+If a participant engages in harassing behavior, the imgix Anti-Abuse Team may take any action they deem appropriate, up to and including expulsion from all imgix spaces and identification of the participant as a harasser to other imgix community members or the general public.
+
+
+## Adopt a code of conduct in your community
+
+If you would like to adopt a policy similar to this one in your community, we recommend looking at Geek Feminism's [community anti-harassment resources](http://geekfeminism.wikia.com/wiki/Community_anti-harassment), including [a freely reusable and modifiable policy](http://geekfeminism.wikia.com/wiki/Community_anti-harassment/Policy).

--- a/README.md
+++ b/README.md
@@ -30,14 +30,6 @@ Harassment includes:
 * Deliberate “outing” of any aspect of a person’s identity without their consent except as necessary to protect other imgix community members or other vulnerable people from intentional abuse
 * Publication of non-harassing private communication
 
-The imgix community prioritizes marginalized people’s safety over privileged people’s comfort. The imgix Anti-Abuse Team will not act on complaints regarding:
-
-* ‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’
-* Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you.”
-* Refusal to explain or debate social justice concepts
-* Communicating in a ‘tone’ you don’t find congenial
-* Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions
-
 
 ## Reporting
 

--- a/incident-response-policy.md
+++ b/incident-response-policy.md
@@ -1,0 +1,164 @@
+# imgix Code of Conduct Incident Response Policy
+
+*This policy is a "living" document, and subject to refinement and expansion in the future.*
+
+This document describes how to respond to reports of harassment, as outlined in the [imgix Code of Conduct](https://imgix.github.io/code-of-conduct/).
+
+## Receiving Harassment Reports
+
+If someone reports harassment the imgix Anti-Abuse team (<codeofconduct@imgix.com>), their report will act as a written account of what happened. This should be kept confidential to as small a group as reasonably possible.
+
+If an imgix employee receives a verbal report, they should themselves write down what they were told as soon as they can, in case they don't get anything better. When possible, verbal reports are usually better conducted in a quiet/private place, for the safety and comfort of the reporter. This also decreases the chances for someone to overhear sensitive information.
+
+If the following information is not volunteered in the written or verbal report, ask for it/include it, but do not pressure them the reporter to provide it:
+
+* Identifying information of the participant doing the harassing
+* The behavior that was in violation
+* The approximate time of the behavior (if different than the time the report was made)
+* The circumstances surrounding the incident
+* Other people involved in the incident
+
+
+## Initial Response to Harassment Reports
+
+### Threats to Physical Well-being
+
+Most harassment complaints aren't of this nature, but if there is a report that someone has committed or is threatening violence towards a community member, or other safety issues:
+
+* If there is any general threat to community members or the safety of anyone involved in the community is in doubt, summon security or police.
+* offer the victim a private place to sit
+* ask "is there a friend or trusted person who you would like to be with you?" (if so, arrange for someone to fetch this person)
+* ask them "how can I help?"
+* provide them with a list of emergency contacts if they need help later
+
+
+### Law Enforcement
+
+If everyone is presently physically safe, **involve law enforcement or security only at a victim's request**.
+
+In many cases, reporting harassment to law enforcement is very unpleasant and may result in further harassment. Forcing victims to go to law enforcement will reduce reports of harassment (but not actual harassment). For more information, see [Why Didn't You Report It](http://meloukhia.net/2010/04/why_didnt_you_report_it/)?
+
+
+### Reports of Harassment That Were Widely Witnessed
+
+These include things like harassing content in conference talks, or harassment that took place in a crowded space.
+
+Simply say **"Thanks, this sounds like a breach of our anti-harassment policy. I am going to convene a meeting of a small group of people and figure out what our response will be."**
+
+
+### Reports of More Private Harassment
+
+Offer the reporter/victim a chance to decide if any further action is taken: **"OK, this sounds like a breach of our anti-harassment policy. If you're OK with it I am going to convene a meeting of a small group of people and figure out what our response will be."** Pause, and see if they say they do not want this. Otherwise, go ahead.
+
+Things not to do:
+
+* Do not overtly invite them to withdraw the complaint or mention that withdrawal is OK: this suggests that you want them to do so, and is therefore coercive. "If you're OK with it [pursuing the complaint]" suggests that you are by default pursuing it and is not coercive.
+* Do not ask for their advice on how to deal with the complaint: this is the Anti-Abuse team's responsibility
+* Do not offer them input into penalties: this is the Anti-Abuse team's responsibility
+* Do not share details of the people involved or incident without specific permission from the victim. This includes sharing with other members of the Anti-Abuse team.
+
+
+## Staff Action in Response to Harassment Reports
+
+You should aim to take action **as soon as reasonably possible**. A response within the next half-day is the ideal timeframe.
+
+
+### Meeting
+
+Available staff should meet as soon as possible after a report to discuss:
+
+* what happened?
+* are we doing anything about it?
+* who is doing those things?
+* when are they doing them?
+
+Neither the complainant nor the alleged harasser should attend. If the event was very widely witnessed, such as a harassing talk, that may be an exception to this guideline. People with a conflict of interest should exclude themselves or if necessary be excluded by others.
+
+
+### Communicate With the Alleged Harasser About the Complaint
+
+As soon as possible, either before or during the above meeting, let the alleged harasser know that there is a complaint about them, let them tell someone their side of the story and that person takes it into the meeting.
+
+
+### Communicate With the Harasser About the Response
+
+As soon as possible after that meeting, let the harasser know what action is being taken. Give them a place to appeal to if there is one, but in the meantime the action stands. **"If you'd like to discuss this further, please contact XYZ, but in the meantime, you must <something something>"**
+
+
+## Possible Sanctions
+
+The guiding principle of the Anti-Abuse team should be **the safety of our community members from harassment**. The Anti-Abuse team should evaluate sanctions in light of whether they provide the safety needed. You and your event are the only people who can judge appropriate sanctions in your community based on the nature of the incident and the responses of the people involved, but some possibilities are:
+
+* warning the harasser to cease their behaviour and that any further reports will result in sanctions
+* requiring that the harasser avoid any interaction with, and physical proximity to, their victim for the remainder of the event
+* ending a talk that violates the policy early
+* not publishing the video or slides of a talk that violated the policy
+* not allowing a speaker who violated the policy to give (further) talks at the event
+* immediately ending any event volunteer responsibilities and privileges the harasser holds
+* requiring that the harasser not volunteer for future events your organization runs (either indefinitely or for a certain time period)
+* requiring that the harasser refund any travel grants and similar they received (this would need to be a condition of the grant at the time of being awarded)
+* requiring that the harasser immediately leave the event and not return
+* banning the harasser from future events (either indefinitely or for a certain time period)
+* removing a harasser from membership of relevant organizations
+
+
+### Employer Reports
+
+If someone harassed someone else while in an official employee capacity, such as while working as paid event staff, while giving a talk about their employer's product, while staffing a sponsor booth, while wearing their employer's branded merchandise, while attempting to recruit someone for a job, or while claiming to represent their employer's views, it may be appropriate to provide a short report of their conduct to their employer.
+
+
+### Don't Require or Encourage Apologies
+
+We **do not** suggest asking for an apology to the victim. You have no responsibility to enforce friendship, reconciliation, or anything beyond lack of harassment between any two given attendees, and in fact doing so can contribute to someone's lack of safety at your event.
+
+Forcing a victim of harassment to acknowledge an apology from their harasser forces further contact with their harasser. It also creates a social expectation that they will accept the apology, forgive their harasser, and return their social connection to its previous status. **A person who has been harassed will often prefer to ignore or avoid their harasser entirely**. Bringing them together with a third party mediator and other attempts to "repair" the situation which require further interaction between them should likewise be avoided.
+
+If the harasser offers to apologize to the victim (especially in person), we suggest strongly discouraging it. If a staff member relays an apology to the victim, it should be brief and not require a response. ("X apologizes and agrees to have no further contact with you" is brief. "X is very sorry that their attempts to woo you were not received in the manner that was intended and will try to do better next time, they're really really sorry and hope that you can find it in your heart to forgive them" is emphatically not.)
+
+If the harasser attempts to press an apology on someone who would clearly prefer to avoid them, or attempts to recruit others to relay messages on their behalf, this may constitute continued harassment.
+
+
+### Data Retention
+
+Each incident reports and responses should be stored indefinitely in the private zebrafishlabs/code-of-conduct-reports repository.
+
+
+## Communicating With the Community
+
+### Principles
+
+Your community may need to see the policy enforced because:
+
+* you want to be transparent to your community and not have secret policies and sanctions that you aren't accountable for
+* the actions of the harasser, or reports of multiple harassment, show that your policy may not be well understood
+* you wish to reassure people that you are serious about anti-harassment
+
+
+### Level of Detail
+
+When discussing the incident with others, it is good to keep the individuals anonymous, generally. An exception may be if the harasser is very central to the community, such as an imgix employee. However, it is useful to:
+
+* offer some idea of the nature of the incident eg "a sexual slide was shown in a talk" or "an attendee physically threatened another attendee" or "an attendee repeatedly harassed another attendee despite multiple requests to cease" or whatever.
+* briefly mention the sanction
+* (briefly! neutrally!) convey any apologies from the harasser, especially if they were backed by actions, for example "the [attendee/speaker/staffer] has agreed that their actions were inappropriate and has voluntarily left the conference"
+
+This helps the community understand the reality of the policy: how and when it gets enforced.
+
+
+### Feedback
+
+The community should be offered the chance to give feedback on the policy and actions. When discussing the incident, always offer an avenue for feedback: this could be verbally, or via Slack, email, etc. One mechanism is usually fine if it's accessible to everyone. (Verbally in person is not accessible to everyone.) 
+
+You will probably prefer that the feedback be private between an individual attendee and the Anti-Abuse team: discussions of harassment incidents on geeky public mailing lists and similar often end up in lengthy (and sometimes harassing!) disputes about the philosophical validity of the notion of harassment.
+
+
+### Informing the Community
+
+Depending on the report and how public the incident was, it may be appropriate to make a short announcement about it, something like:
+
+"<thing> happened. This was a violation of our policy. We apologise for this. We have taken <action>. This is a good time for all attendees to review our policy at <location>. If anyone would like to discuss this further they can <contact us somehow>."
+
+
+### Evaluation
+
+After we have had a chance to observe how the code of conduct works in real-world situations, we may wish to change the policy to better address them. Did anything unforeseen happen that there should be a rule about? Sometimes an unacceptable behavior does not warrant a whole new rule, but should be listed as a specific example of unacceptable behavior under an existing rule.

--- a/incident-response-policy.md
+++ b/incident-response-policy.md
@@ -6,11 +6,11 @@ This document describes how to respond to reports of harassment, as outlined in 
 
 ## Receiving Harassment Reports
 
-If someone reports harassment the imgix Anti-Abuse team (<codeofconduct@imgix.com>), their report will act as a written account of what happened. This should be kept confidential to as small a group as reasonably possible.
+If someone reports harassment to the imgix Anti-Abuse team (<codeofconduct@imgix.com>), their report will act as a written account of what happened. This should be kept confidential to as small a group as reasonably possible.
 
 If an imgix employee receives a verbal report, they should themselves write down what they were told as soon as they can, in case they don't get anything better. When possible, verbal reports are usually better conducted in a quiet/private place, for the safety and comfort of the reporter. This also decreases the chances for someone to overhear sensitive information.
 
-If the following information is not volunteered in the written or verbal report, ask for it/include it, but do not pressure them the reporter to provide it:
+If the following information is not volunteered in the written or verbal report, ask for it/include it, but do not pressure the reporter to provide it:
 
 * Identifying information of the participant doing the harassing
 * The behavior that was in violation
@@ -156,7 +156,7 @@ You will probably prefer that the feedback be private between an individual atte
 
 Depending on the report and how public the incident was, it may be appropriate to make a short announcement about it, something like:
 
-"<thing> happened. This was a violation of our policy. We apologise for this. We have taken <action>. This is a good time for all attendees to review our policy at <location>. If anyone would like to discuss this further they can <contact us somehow>."
+"[thing] happened. This was a violation of our policy. We apologise for this. We have taken [action]. This is a good time for all attendees to review our policy at [location]. If anyone would like to discuss this further they can [contact us somehow]."
 
 
 ### Evaluation

--- a/index.html
+++ b/index.html
@@ -31,13 +31,13 @@
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/theme-white/script.js'></script>
 
   <!-- Meta -->
-  <meta content="imgix-community Code of Conduct" property="og:title">
-  <meta content="The Code of Conduct for the imgix-community Slack group" name="description">
+  <meta content="imgix Code of Conduct" property="og:title">
+  <meta content="The Code of Conduct for imgix-hosted spaces" name="description">
 
   <!-- Initializer -->
   <script>
     Flatdoc.run({
-      fetcher: Flatdoc.github('imgix/slack-code-of-conduct')
+      fetcher: Flatdoc.github('imgix/code-of-conduct')
     });
   </script>
 </head>
@@ -47,8 +47,8 @@
     <div class='left'>
       <h1>imgix-community Code of Conduct</h1>
       <ul>
-        <li><a href='https://github.com/imgix/slack-code-of-conduct'>View on GitHub</a></li>
-        <li><a href='https://github.com/imgix/slack-code-of-conduct/issues'>Issues</a></li>
+        <li><a href='https://github.com/imgix/code-of-conduct'>View on GitHub</a></li>
+        <li><a href='https://github.com/imgix/code-of-conduct/issues'>Issues</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
New code of conduct and incident response policy, as outlined in https://github.com/zebrafishlabs/rfcs/blob/master/text/0020-code-of-conduct.md.

This should be good to merge after a feedback pass.
